### PR TITLE
fix: use ~/.config/clawport-ui for .env.local when package dir not writable

### DIFF
--- a/bin/clawport.mjs
+++ b/bin/clawport.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'node:path'
+import { dirname, resolve, join } from 'node:path'
 import { spawn } from 'node:child_process'
 import { existsSync, readFileSync, accessSync, constants } from 'node:fs'
+import { homedir } from 'node:os'
 import { execSync } from 'node:child_process'
 import { createServer } from 'node:net'
 
@@ -25,6 +26,40 @@ if (major < 22) {
 
 const __filename = fileURLToPath(import.meta.url)
 const PKG_ROOT = resolve(dirname(__filename), '..')
+
+const USER_CONFIG_DIR = join(homedir(), '.config', 'clawport-ui')
+const ENV_LOCAL_FILENAME = '.env.local'
+
+/** Path to .env.local: package root (preferred) or user config dir (for global installs). */
+function getEnvLocalPath() {
+  const pkgEnv = resolve(PKG_ROOT, ENV_LOCAL_FILENAME)
+  if (existsSync(pkgEnv)) return pkgEnv
+  const userEnv = resolve(USER_CONFIG_DIR, ENV_LOCAL_FILENAME)
+  if (existsSync(userEnv)) return userEnv
+  return null
+}
+
+/** Load .env.local into process.env so Next.js and status/doctor see the vars. */
+function loadEnvLocal() {
+  const path = getEnvLocalPath()
+  if (!path) return
+  try {
+    const content = readFileSync(path, 'utf-8')
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed && !trimmed.startsWith('#')) {
+        const eq = trimmed.indexOf('=')
+        if (eq > 0) {
+          const key = trimmed.slice(0, eq).trim()
+          const value = trimmed.slice(eq + 1).trim()
+          if (key) process.env[key] = value
+        }
+      }
+    }
+  } catch (_) {}
+}
+
+loadEnvLocal()
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -153,10 +188,10 @@ async function cmdStatus() {
     console.log(`    ${dim('Start it with: openclaw gateway run')}`)
   }
 
-  // Check .env.local
-  const envPath = resolve(PKG_ROOT, '.env.local')
+  // Check .env.local (package root or ~/.config/clawport-ui)
+  const envPath = getEnvLocalPath()
   console.log()
-  if (existsSync(envPath)) {
+  if (envPath && existsSync(envPath)) {
     console.log(`  ${green('+')} .env.local found`)
     const content = readFileSync(envPath, 'utf-8')
     const lines = content.split('\n').filter((l) => l && !l.startsWith('#'))
@@ -175,6 +210,9 @@ async function cmdStatus() {
   }
 
   console.log()
+  if (envPath) {
+    console.log(`  ${dim(`Config: ${envPath}`)}`)
+  }
   console.log(`  ${dim(`Package root: ${PKG_ROOT}`)}`)
   console.log()
 }
@@ -212,12 +250,12 @@ async function cmdDoctor() {
   const gatewayUp = await checkGateway()
   check(gatewayUp, 'Gateway reachable at localhost:18789', 'Start it with: openclaw gateway run')
 
-  // 5. Configuration -- .env.local with required vars
-  const envPath = resolve(PKG_ROOT, '.env.local')
+  // 5. Configuration -- .env.local with required vars (package root or ~/.config/clawport-ui)
+  const envPath = getEnvLocalPath()
   const requiredVars = ['WORKSPACE_PATH', 'OPENCLAW_BIN', 'OPENCLAW_GATEWAY_TOKEN']
   let envOk = false
   let envFix = 'Run: clawport setup'
-  if (existsSync(envPath)) {
+  if (envPath && existsSync(envPath)) {
     const content = readFileSync(envPath, 'utf-8')
     const missing = requiredVars.filter((v) => !content.includes(`${v}=`))
     if (missing.length === 0) {

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -4,7 +4,8 @@
 // Usage: npm run setup
 
 import { execSync } from 'node:child_process'
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, accessSync } from 'node:fs'
+import { constants } from 'node:fs'
 import { resolve, join } from 'node:path'
 import { createInterface } from 'node:readline'
 import { homedir } from 'node:os'
@@ -210,7 +211,28 @@ async function main() {
 
   // Support --cwd flag for CLI usage (clawport setup writes .env.local into the package dir)
   const cwdFlag = process.argv.find((a) => a.startsWith('--cwd='))
-  const targetDir = cwdFlag ? cwdFlag.split('=')[1] : process.cwd()
+  let targetDir = cwdFlag ? cwdFlag.split('=')[1] : process.cwd()
+
+  // When installed globally (e.g. /usr/lib/node_modules/clawport-ui), targetDir may not be writable.
+  // Use ~/.config/clawport-ui/.env.local in that case so setup works without sudo.
+  function canWriteToDir(dir) {
+    try {
+      accessSync(dir, constants.W_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  if (!canWriteToDir(targetDir)) {
+    const userConfigDir = join(homedir(), '.config', 'clawport-ui')
+    if (!existsSync(userConfigDir)) {
+      mkdirSync(userConfigDir, { recursive: true })
+    }
+    targetDir = userConfigDir
+    console.log(`  ${yellow('!')} Package directory is not writable; using ${dim(targetDir)} for .env.local`)
+    console.log()
+  }
 
   // Check if .env.local already exists
   const envPath = resolve(targetDir, '.env.local')
@@ -254,7 +276,7 @@ async function main() {
   writeFileSync(envPath, content, 'utf-8')
 
   console.log()
-  console.log(`  ${green('Done!')} .env.local written.`)
+  console.log(`  ${green('Done!')} .env.local written${targetDir !== (cwdFlag ? cwdFlag.split('=')[1] : process.cwd()) ? ` to ${dim(targetDir)}` : ''}.`)
   console.log()
   const startCmd = cwdFlag ? 'clawport dev' : 'npm run dev'
   console.log(`  Next steps:`)


### PR DESCRIPTION
When clawport-ui is installed globally (e.g. `npm install -g`), the package lives in a system path like `/usr/lib/node_modules/clawport-ui` which is not writable by normal users. `clawport setup` then fails with EACCES when writing `.env.local`.

**Changes:**
- **setup.mjs**: If the target dir (package root when run via `clawport setup`) is not writable, write `.env.local` to `~/.config/clawport-ui/` instead and create that dir if needed.
- **bin/clawport.mjs**: Load `.env.local` from package root or, if missing, from `~/.config/clawport-ui` so `dev`/`start`/`status`/`doctor` work with global installs.

**Testing:** Run `npm install -g clawport-ui` (or install to a read-only prefix), then `clawport setup` — it should write to `~/.config/clawport-ui/.env.local` and `clawport dev` should start correctly.

Fixes #5