### PR TITLE
feat: server-side chat persistence for cross-device sync

### DIFF
--- a/app/api/conversations/[agentId]/route.ts
+++ b/app/api/conversations/[agentId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from 'next/server'
+import { getConversation, appendMessages, clearConversation, StoredMessage } from '@/lib/conversation-store'
+import { apiErrorResponse } from '@/lib/api-error'
+
+const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/
+
+function isValidMessage(m: unknown): m is StoredMessage {
+  if (!m || typeof m !== 'object') return false
+  const msg = m as Record<string, unknown>
+  return (
+    typeof msg.id === 'string' && msg.id.length > 0 &&
+    (msg.role === 'user' || msg.role === 'assistant') &&
+    typeof msg.content === 'string' &&
+    (typeof msg.timestamp === 'number' || msg.timestamp === undefined)
+  )
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  try {
+    const { agentId } = await params
+    if (!AGENT_ID_RE.test(agentId)) {
+      return Response.json({ error: 'Invalid agent ID' }, { status: 400 })
+    }
+    const messages = getConversation(agentId)
+    return Response.json(messages)
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to load conversation')
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  try {
+    const { agentId } = await params
+    if (!AGENT_ID_RE.test(agentId)) {
+      return Response.json({ error: 'Invalid agent ID' }, { status: 400 })
+    }
+
+    const body = await req.json()
+    const messages: unknown[] = body.messages
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return Response.json({ error: 'messages array required' }, { status: 400 })
+    }
+
+    if (!messages.every(isValidMessage)) {
+      return Response.json({ error: 'Invalid message format: each message needs id, role (user|assistant), and content' }, { status: 400 })
+    }
+
+    appendMessages(agentId, messages)
+    return Response.json({ ok: true })
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to save messages')
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  try {
+    const { agentId } = await params
+    if (!AGENT_ID_RE.test(agentId)) {
+      return Response.json({ error: 'Invalid agent ID' }, { status: 400 })
+    }
+    clearConversation(agentId)
+    return Response.json({ ok: true })
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to clear conversation')
+  }
+}

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,0 +1,11 @@
+import { listConversations } from '@/lib/conversation-store'
+import { apiErrorResponse } from '@/lib/api-error'
+
+export async function GET() {
+  try {
+    const conversations = listConversations()
+    return Response.json(conversations)
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to list conversations')
+  }
+}

--- a/app/api/onboarded/route.ts
+++ b/app/api/onboarded/route.ts
@@ -1,0 +1,21 @@
+import { existsSync, writeFileSync, mkdirSync } from 'fs'
+import path from 'path'
+import { requireEnv } from '@/lib/env'
+
+function getFlagPath(): string {
+  const dir = path.resolve(requireEnv('WORKSPACE_PATH'), '..', 'clawport')
+  return path.join(dir, '.onboarded')
+}
+
+export async function GET() {
+  const onboarded = existsSync(getFlagPath())
+  return Response.json({ onboarded })
+}
+
+export async function POST() {
+  const flagPath = getFlagPath()
+  const dir = path.dirname(flagPath)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(flagPath, new Date().toISOString(), 'utf-8')
+  return Response.json({ ok: true })
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -6,7 +6,8 @@ import { AgentList, AgentListMobile } from '@/components/chat/AgentList'
 import { ConversationView } from '@/components/chat/ConversationView'
 import {
   loadConversations, saveConversations, getOrCreateConversation,
-  markRead, type ConversationStore
+  markRead, loadConversationFromServer, loadAllConversationMeta,
+  type ConversationStore
 } from '@/lib/conversations'
 
 function MessengerApp() {
@@ -26,9 +27,46 @@ function MessengerApp() {
     })
   }, [])
 
-  // Load conversations from localStorage
+  // Load conversations: localStorage first (instant), then merge server data
   useEffect(() => {
-    setConversations(loadConversations())
+    const local = loadConversations()
+    setConversations(local)
+
+    // Fetch server-side conversation metadata, then load full conversations
+    loadAllConversationMeta().then(async (metas) => {
+      if (metas.length === 0) return
+      const serverStore: ConversationStore = {}
+      for (const meta of metas) {
+        const messages = await loadConversationFromServer(meta.agentId)
+        if (messages.length > 0) {
+          serverStore[meta.agentId] = {
+            agentId: meta.agentId,
+            messages,
+            unread: 0,
+            lastActivity: meta.lastActivity,
+          }
+        }
+      }
+      // Merge: server messages take priority, dedup by id
+      setConversations(prev => {
+        const merged = { ...prev }
+        for (const [agentId, serverConv] of Object.entries(serverStore)) {
+          const localConv = merged[agentId]
+          if (!localConv) {
+            merged[agentId] = serverConv
+          } else {
+            const existingIds = new Set(localConv.messages.map(m => m.id))
+            const newFromServer = serverConv.messages.filter(m => !existingIds.has(m.id))
+            if (newFromServer.length > 0) {
+              const allMessages = [...localConv.messages, ...newFromServer]
+                .sort((a, b) => a.timestamp - b.timestamp)
+              merged[agentId] = { ...localConv, messages: allMessages }
+            }
+          }
+        }
+        return merged
+      })
+    })
   }, [])
 
   // Save conversations whenever they change

--- a/components/OnboardingWizard.tsx
+++ b/components/OnboardingWizard.tsx
@@ -96,7 +96,7 @@ export function OnboardingWizard({ forceOpen, onClose }: OnboardingWizardProps) 
   const [agentsError, setAgentsError] = useState<string | null>(null)
   const [cronsError, setCronsError] = useState<string | null>(null)
 
-  // First-run detection
+  // First-run detection — check both localStorage and server
   useEffect(() => {
     if (forceOpen) {
       setLocalName(settings.portalName ?? '')
@@ -105,9 +105,20 @@ export function OnboardingWizard({ forceOpen, onClose }: OnboardingWizardProps) 
       setVisible(true)
       return
     }
-    if (typeof window !== 'undefined' && !localStorage.getItem('clawport-onboarded')) {
-      setVisible(true)
+    if (typeof window !== 'undefined' && localStorage.getItem('clawport-onboarded')) {
+      return // already onboarded locally
     }
+    // Check server-side flag (covers cross-device scenario)
+    fetch('/api/onboarded')
+      .then(r => r.json())
+      .then(data => {
+        if (data.onboarded) {
+          localStorage.setItem('clawport-onboarded', '1')
+        } else {
+          setVisible(true)
+        }
+      })
+      .catch(() => setVisible(true))
   }, [forceOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Run system checks when we reach the system check step
@@ -181,6 +192,7 @@ export function OnboardingWizard({ forceOpen, onClose }: OnboardingWizardProps) 
     } else {
       if (!forceOpen) {
         localStorage.setItem('clawport-onboarded', '1')
+        fetch('/api/onboarded', { method: 'POST' }).catch(() => {})
       }
       setVisible(false)
       onClose?.()

--- a/components/chat/ConversationView.tsx
+++ b/components/chat/ConversationView.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Agent } from '@/lib/types'
 import type { Conversation, ConversationStore, Message, MediaAttachment } from '@/lib/conversations'
-import { parseMedia, addMessage, updateLastMessage } from '@/lib/conversations'
+import { parseMedia, addMessage, updateLastMessage, syncMessagesToServer, clearConversationOnServer } from '@/lib/conversations'
 import { buildApiContent } from '@/lib/multimodal'
 import { generateId } from '@/lib/id'
 import { useSettings } from '@/app/settings-provider'
@@ -365,6 +365,9 @@ export function ConversationView({ agent, conversation, onUpdate, onBack }: Conv
       return next
     })
 
+    // Sync user message to server
+    syncMessagesToServer(agent.id, [userMsg])
+
     setIsStreaming(true)
 
     // Use ref to read latest messages (avoids stale closure)
@@ -411,6 +414,16 @@ export function ConversationView({ agent, conversation, onUpdate, onBack }: Conv
 
       const finalContent = fullContent
       onUpdate(agent.id, prev => updateLastMessage(prev, agent.id, assistantMsgId, finalContent, false))
+
+      // Sync assistant response to server
+      if (finalContent) {
+        syncMessagesToServer(agent.id, [{
+          id: assistantMsgId,
+          role: 'assistant',
+          content: finalContent,
+          timestamp: Date.now(),
+        }])
+      }
     } catch {
       onUpdate(agent.id, prev => updateLastMessage(prev, agent.id, assistantMsgId, 'Error getting response. Check API connection.', false))
     } finally {
@@ -647,6 +660,7 @@ export function ConversationView({ agent, conversation, onUpdate, onBack }: Conv
         lastActivity: Date.now(),
       }
     }))
+    clearConversationOnServer(agent.id)
   }
 
   const hasContent = input.trim().length > 0 || pendingAttachments.length > 0

--- a/lib/conversation-store.ts
+++ b/lib/conversation-store.ts
@@ -1,0 +1,136 @@
+import { readFileSync, appendFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { requireEnv } from '@/lib/env'
+
+/** Serializable chat message (no isStreaming, no media blobs — UI-only fields) */
+export interface StoredMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: number
+}
+
+/** Lightweight metadata returned when listing all conversations */
+export interface ConversationMeta {
+  agentId: string
+  lastActivity: number
+  messageCount: number
+  lastMessage: string | null
+}
+
+/** Derive the conversations directory from WORKSPACE_PATH */
+function getConversationsDir(): string {
+  return path.resolve(requireEnv('WORKSPACE_PATH'), '..', 'clawport', 'conversations')
+}
+
+/**
+ * Parse a single JSONL line into a StoredMessage.
+ * Returns null if the line can't be parsed or is missing required fields.
+ */
+function parseLine(line: string): StoredMessage | null {
+  if (!line.trim()) return null
+  try {
+    const obj = JSON.parse(line)
+    if (typeof obj.id !== 'string' || !obj.id) return null
+    if (obj.role !== 'user' && obj.role !== 'assistant') return null
+    if (typeof obj.content !== 'string') return null
+    return {
+      id: obj.id,
+      role: obj.role,
+      content: obj.content,
+      timestamp: typeof obj.timestamp === 'number' ? obj.timestamp : 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read all messages for an agent conversation from its JSONL file.
+ * Returns StoredMessage[] sorted oldest-first by timestamp.
+ */
+export function getConversation(agentId: string): StoredMessage[] {
+  const dir = getConversationsDir()
+  const filePath = path.join(dir, `${agentId}.jsonl`)
+
+  if (!existsSync(filePath)) return []
+
+  try {
+    const content = readFileSync(filePath, 'utf-8')
+    const messages: StoredMessage[] = []
+    for (const line of content.split('\n')) {
+      const msg = parseLine(line)
+      if (msg) messages.push(msg)
+    }
+    messages.sort((a, b) => a.timestamp - b.timestamp)
+    return messages
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Append messages to an agent's JSONL file.
+ * Creates the directory and file if they don't exist.
+ * Deduplicates by message ID to prevent duplicates on retry.
+ */
+export function appendMessages(agentId: string, messages: StoredMessage[]): void {
+  const dir = getConversationsDir()
+  mkdirSync(dir, { recursive: true })
+
+  const filePath = path.join(dir, `${agentId}.jsonl`)
+
+  let newMessages = messages
+  if (existsSync(filePath)) {
+    const existing = getConversation(agentId)
+    const existingIds = new Set(existing.map(m => m.id))
+    newMessages = messages.filter(m => !existingIds.has(m.id))
+    if (newMessages.length === 0) return
+  }
+
+  const lines = newMessages.map(m => JSON.stringify({
+    id: m.id,
+    role: m.role,
+    content: m.content,
+    timestamp: m.timestamp,
+  }))
+
+  appendFileSync(filePath, lines.join('\n') + '\n', 'utf-8')
+}
+
+/**
+ * Clear an agent's conversation by removing the JSONL file.
+ */
+export function clearConversation(agentId: string): void {
+  const dir = getConversationsDir()
+  const filePath = path.join(dir, `${agentId}.jsonl`)
+
+  if (existsSync(filePath)) {
+    writeFileSync(filePath, '', 'utf-8')
+  }
+}
+
+/**
+ * List metadata for all stored conversations by scanning the conversations directory.
+ */
+export function listConversations(): ConversationMeta[] {
+  const dir = getConversationsDir()
+  if (!existsSync(dir)) return []
+
+  try {
+    const files = readdirSync(dir).filter(f => f.endsWith('.jsonl'))
+    return files.map(f => {
+      const agentId = f.replace('.jsonl', '')
+      const messages = getConversation(agentId)
+      const last = messages.length > 0 ? messages[messages.length - 1] : null
+      return {
+        agentId,
+        lastActivity: last ? last.timestamp : 0,
+        messageCount: messages.length,
+        lastMessage: last ? last.content.slice(0, 100) : null,
+      }
+    }).filter(m => m.messageCount > 0)
+  } catch {
+    return []
+  }
+}

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -92,6 +92,53 @@ export function updateLastMessage(store: ConversationStore, agentId: string, msg
   return { ...store, [agentId]: { ...conv, messages: msgs } }
 }
 
+/* ── Server sync helpers ─────────────────────────────────── */
+
+/** Fetch a single agent's conversation from the server. */
+export async function loadConversationFromServer(agentId: string): Promise<Message[]> {
+  try {
+    const res = await fetch(`/api/conversations/${agentId}`)
+    if (!res.ok) return []
+    const messages: Message[] = await res.json()
+    return messages
+  } catch {
+    return []
+  }
+}
+
+/** Persist messages to the server (fire-and-forget safe). */
+export async function syncMessagesToServer(agentId: string, messages: Message[]): Promise<void> {
+  try {
+    await fetch(`/api/conversations/${agentId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messages: messages
+          .filter(m => m.role === 'user' || m.role === 'assistant')
+          .map(m => ({ id: m.id, role: m.role, content: m.content, timestamp: m.timestamp })),
+      }),
+    })
+  } catch { /* fire-and-forget */ }
+}
+
+/** Clear a conversation on the server. */
+export async function clearConversationOnServer(agentId: string): Promise<void> {
+  try {
+    await fetch(`/api/conversations/${agentId}`, { method: 'DELETE' })
+  } catch { /* fire-and-forget */ }
+}
+
+/** Fetch metadata for all conversations from the server. */
+export async function loadAllConversationMeta(): Promise<Array<{ agentId: string; lastActivity: number; messageCount: number }>> {
+  try {
+    const res = await fetch('/api/conversations')
+    if (!res.ok) return []
+    return await res.json()
+  } catch {
+    return []
+  }
+}
+
 export function parseMedia(content: string): MediaAttachment[] {
   const media: MediaAttachment[] = []
 


### PR DESCRIPTION
## Summary

- **Server-side chat persistence** using JSONL files (mirrors the existing `kanban/chat-store.ts` pattern) — conversations now sync across devices automatically
- **Cross-device onboarding flag** — the welcome wizard no longer reappears on every new device/browser
- localStorage kept as a fast local cache with server data merged on load

## Problem

ClawPort stores conversations in browser `localStorage` only. When accessing ClawPort from multiple devices (e.g. via Tailscale Serve), each device has a completely separate chat history, and the onboarding wizard shows up every time.

## What changed

**New files:**
- `lib/conversation-store.ts` — JSONL-based server storage (read, append, clear, list)
- `app/api/conversations/[agentId]/route.ts` — GET/POST/DELETE per-agent conversations
- `app/api/conversations/route.ts` — GET to list all conversation metadata
- `app/api/onboarded/route.ts` — GET/POST for onboarding completion flag

**Modified files:**
- `lib/conversations.ts` — added async server sync helpers (`syncMessagesToServer`, `loadConversationFromServer`, `clearConversationOnServer`, `loadAllConversationMeta`)
- `app/chat/page.tsx` — loads from localStorage instantly, then merges server data in background
- `components/chat/ConversationView.tsx` — syncs user & assistant messages to server after each exchange, clears server on `/clear`
- `components/OnboardingWizard.tsx` — checks server-side flag before showing wizard

## Design decisions

- **JSONL format** — consistent with existing kanban chat persistence pattern
- **No new dependencies** — uses Node.js `fs` module only
- **Media not persisted server-side** — base64 blobs stay in localStorage to keep server files small
- **System messages not persisted** — slash command results are ephemeral UI state
- **Deduplication by message ID** — prevents duplicates on retry
- **Storage location:** `WORKSPACE_PATH/../clawport/conversations/{agentId}.jsonl`