### PR TITLE
Improve chat loading state and dedupe agent fetches

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import type { Agent } from '@/lib/types'
 import { AgentList, AgentListMobile } from '@/components/chat/AgentList'
 import { ConversationView } from '@/components/chat/ConversationView'
+import { fetchAgentsCached } from '@/lib/agents-client'
 import {
   loadConversations, saveConversations, getOrCreateConversation,
   markRead, type ConversationStore, type Message,
@@ -13,18 +14,32 @@ import {
 function MessengerApp() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const urlAgentId = searchParams.get('agent')
   const [agents, setAgents] = useState<Agent[]>([])
   const [conversations, setConversations] = useState<ConversationStore>({})
-  const [activeAgentId, setActiveAgentId] = useState<string | null>(searchParams.get('agent'))
+  const [activeAgentId, setActiveAgentId] = useState<string | null>(urlAgentId)
   const [loading, setLoading] = useState(true)
-  const [mobileShowConversation, setMobileShowConversation] = useState(!!searchParams.get('agent'))
+  const [mobileShowConversation, setMobileShowConversation] = useState(!!urlAgentId)
 
   // Load agents
   useEffect(() => {
-    fetch('/api/agents').then(r => r.json()).then((data: Agent[]) => {
-      setAgents(data)
-      setLoading(false)
-    })
+    let cancelled = false
+    setLoading(true)
+    fetchAgentsCached()
+      .then((data) => {
+        if (cancelled) return
+        setAgents(data)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setAgents([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   // Load conversations from localStorage
@@ -98,15 +113,49 @@ function MessengerApp() {
     })
   }, [loading, agents])
 
-  // Set default active agent on desktop only (don't auto-select on mobile)
+  // Keep local state in sync with URL query changes
   useEffect(() => {
-    if (!loading && agents.length > 0 && !activeAgentId) {
-      // On desktop (>= 768px), select first agent
-      if (window.innerWidth >= 768) {
-        setActiveAgentId(agents[0].id)
+    const isDesktop = window.innerWidth >= 768
+
+    if (urlAgentId) {
+      if (urlAgentId !== activeAgentId) {
+        setActiveAgentId(urlAgentId)
       }
+      setMobileShowConversation(true)
+      return
     }
-  }, [loading, agents, activeAgentId])
+
+    setMobileShowConversation(false)
+    if (!isDesktop && activeAgentId) {
+      setActiveAgentId(null)
+    }
+  }, [urlAgentId, activeAgentId])
+
+  // Normalize invalid URL state and set desktop default agent
+  useEffect(() => {
+    if (loading || agents.length === 0) return
+    const isDesktop = window.innerWidth >= 768
+    const hasUrlAgent = !!urlAgentId && agents.some((agent) => agent.id === urlAgentId)
+
+    if (urlAgentId && !hasUrlAgent) {
+      if (isDesktop) {
+        const fallbackId = agents[0].id
+        setActiveAgentId(fallbackId)
+        router.replace(`/chat?agent=${fallbackId}`, { scroll: false })
+      } else {
+        setActiveAgentId(null)
+        setMobileShowConversation(false)
+        router.replace('/chat', { scroll: false })
+      }
+      return
+    }
+
+    if (!urlAgentId && isDesktop && !activeAgentId) {
+      const fallbackId = agents[0].id
+      setActiveAgentId(fallbackId)
+      router.replace(`/chat?agent=${fallbackId}`, { scroll: false })
+    }
+  }, [loading, agents, urlAgentId, activeAgentId, router])
 
   const handleSelectAgent = useCallback((agent: Agent) => {
     setActiveAgentId(agent.id)
@@ -125,7 +174,8 @@ function MessengerApp() {
 
   const handleMobileBack = useCallback(() => {
     setMobileShowConversation(false)
-  }, [])
+    router.replace('/chat', { scroll: false })
+  }, [router])
 
   const activeAgent = agents.find(a => a.id === activeAgentId) || null
 
@@ -171,7 +221,11 @@ function MessengerApp() {
         className="hidden md:flex md:flex-col"
         style={{ flex: 1, height: '100%' }}
       >
-        {activeAgent && conversations[activeAgent.id] ? (
+        {loading ? (
+          <LoadingState />
+        ) : agents.length === 0 ? (
+          <NoAgentsState />
+        ) : activeAgent && conversations[activeAgent.id] ? (
           <ConversationView
             key={activeAgent.id}
             agent={activeAgent}
@@ -203,6 +257,69 @@ function MessengerApp() {
           />
         </div>
       )}
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div style={{
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'var(--bg)',
+      gap: 'var(--space-3)',
+      padding: 'var(--space-8)',
+    }}>
+      <div
+        className="animate-spin"
+        style={{
+          width: 24,
+          height: 24,
+          border: '2px solid var(--fill-tertiary)',
+          borderTopColor: 'var(--accent)',
+          borderRadius: '50%',
+        }}
+      />
+      <div style={{
+        fontSize: 'var(--text-subheadline)',
+        color: 'var(--text-secondary)',
+      }}>
+        Loading conversations...
+      </div>
+    </div>
+  )
+}
+
+function NoAgentsState() {
+  return (
+    <div style={{
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'var(--bg)',
+      gap: 'var(--space-2)',
+      padding: 'var(--space-8)',
+      textAlign: 'center',
+    }}>
+      <div style={{
+        fontSize: 'var(--text-title3)',
+        fontWeight: 'var(--weight-bold)',
+        color: 'var(--text-primary)',
+      }}>
+        No agents found
+      </div>
+      <div style={{
+        fontSize: 'var(--text-subheadline)',
+        color: 'var(--text-secondary)',
+        lineHeight: 'var(--leading-relaxed)',
+      }}>
+        Add agents in your OpenClaw workspace, then refresh this page.
+      </div>
     </div>
   )
 }

--- a/components/NavLinks.tsx
+++ b/components/NavLinks.tsx
@@ -7,6 +7,7 @@ import { Map, MessageSquare, Clock, Activity, Brain, Columns3, BookOpen, Setting
 import type { LucideIcon } from 'lucide-react';
 import type { CronJob } from '@/lib/types';
 import { useSettings } from '@/app/settings-provider';
+import { fetchAgentsCached } from '@/lib/agents-client';
 
 function getInitials(name: string | null): string {
   if (!name) return '??'
@@ -51,19 +52,17 @@ export function NavLinks({ bottomSlot }: { bottomSlot?: React.ReactNode } = {}) 
 
   // Fetch agent count
   useEffect(() => {
-    fetch('/api/agents')
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      })
-      .then((data: unknown) => {
-        if (Array.isArray(data)) {
-          setAgentCount(data.length);
-        }
+    let cancelled = false;
+    fetchAgentsCached()
+      .then((agents) => {
+        if (!cancelled) setAgentCount(agents.length);
       })
       .catch(() => {
-        setAgentCount(null);
+        if (!cancelled) setAgentCount(null);
       });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Fetch cron error count

--- a/lib/agents-client.test.ts
+++ b/lib/agents-client.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchAgentsCached, resetAgentsCacheForTests } from '@/lib/agents-client'
+import type { Agent } from '@/lib/types'
+
+function mockResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response
+}
+
+const SAMPLE_AGENTS: Agent[] = [
+  {
+    id: 'alpha',
+    name: 'Alpha',
+    title: 'Lead',
+    reportsTo: null,
+    directReports: [],
+    soulPath: null,
+    soul: null,
+    voiceId: null,
+    color: '#4477ff',
+    emoji: 'robot',
+    model: null,
+    tools: [],
+    crons: [],
+    memoryPath: null,
+    description: '',
+  },
+]
+
+describe('fetchAgentsCached', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    resetAgentsCacheForTests()
+  })
+
+  it('deduplicates in-flight requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(SAMPLE_AGENTS))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const [a, b] = await Promise.all([
+      fetchAgentsCached({ ttlMs: 1000 }),
+      fetchAgentsCached({ ttlMs: 1000 }),
+    ])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(a).toEqual(SAMPLE_AGENTS)
+    expect(b).toEqual(SAMPLE_AGENTS)
+  })
+
+  it('returns cached data inside TTL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(SAMPLE_AGENTS))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchAgentsCached({ ttlMs: 1000 })
+    await fetchAgentsCached({ ttlMs: 1000 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes after TTL expires', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-11T00:00:00Z'))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(mockResponse(SAMPLE_AGENTS))
+      .mockResolvedValueOnce(mockResponse([
+        {
+          id: 'beta',
+          name: 'Beta',
+          title: 'Worker',
+          reportsTo: null,
+          directReports: [],
+          soulPath: null,
+          soul: null,
+          voiceId: null,
+          color: '#44cc88',
+          emoji: 'worker',
+          model: null,
+          tools: [],
+          crons: [],
+          memoryPath: null,
+          description: '',
+        },
+      ]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = await fetchAgentsCached({ ttlMs: 50 })
+    vi.advanceTimersByTime(51)
+    const second = await fetchAgentsCached({ ttlMs: 50 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(first[0].id).toBe('alpha')
+    expect(second[0].id).toBe('beta')
+  })
+
+  it('bypasses cache when forced', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(mockResponse(SAMPLE_AGENTS))
+      .mockResolvedValueOnce(mockResponse(SAMPLE_AGENTS))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchAgentsCached({ ttlMs: 1000 })
+    await fetchAgentsCached({ force: true, ttlMs: 1000 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/lib/agents-client.ts
+++ b/lib/agents-client.ts
@@ -1,0 +1,52 @@
+import type { Agent } from '@/lib/types'
+
+const DEFAULT_TTL_MS = 5_000
+
+let cache: { agents: Agent[]; expiresAt: number } | null = null
+let inFlight: Promise<Agent[]> | null = null
+
+async function fetchAgentsFromApi(): Promise<Agent[]> {
+  const res = await fetch('/api/agents')
+  if (!res.ok) {
+    throw new Error(`Failed to fetch agents: HTTP ${res.status}`)
+  }
+  const data = await res.json()
+  if (!Array.isArray(data)) {
+    throw new Error('Failed to fetch agents: invalid payload')
+  }
+  return data as Agent[]
+}
+
+export async function fetchAgentsCached(options?: {
+  force?: boolean
+  ttlMs?: number
+}): Promise<Agent[]> {
+  const force = options?.force ?? false
+  const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS
+  const now = Date.now()
+
+  if (!force && cache && cache.expiresAt > now) {
+    return cache.agents
+  }
+
+  if (inFlight) return inFlight
+
+  inFlight = fetchAgentsFromApi()
+    .then((agents) => {
+      cache = {
+        agents,
+        expiresAt: Date.now() + Math.max(0, ttlMs),
+      }
+      return agents
+    })
+    .finally(() => {
+      inFlight = null
+    })
+
+  return inFlight
+}
+
+export function resetAgentsCacheForTests() {
+  cache = null
+  inFlight = null
+}


### PR DESCRIPTION
Follow-up to #10 with a smaller, focused scope based on maintainer feedback.

## What changed
- add a shared client-side agent fetch cache (`lib/agents-client.ts`) with in-flight dedupe and short TTL
- use shared cache in `NavLinks` and `chat` page to avoid duplicate `/api/agents` requests
- improve `/chat` UX state handling:
  - add explicit loading state for desktop conversation pane
  - add explicit no-agents state
  - sync URL `?agent=` param with selected conversation state
  - normalize invalid `?agent=` values to a valid desktop fallback
  - make mobile back clear URL state consistently

## Locale scope
- this PR intentionally does not change locale behavior
- the app remains English-by-default, matching current `main`
- any future i18n work should keep English as the safe default (or `auto` with `en` fallback) and should be reviewed separately from these UX fixes

## Why
- keeps changes independent from localization/server-prompt/docs work
- addresses the two examples suggested in review: chat loading state improvements and agent fetch caching

## Validation
- `npm run build` ✅
- `npm test -- lib/agents-client.test.ts` ✅
- `npm test` still shows existing baseline failures in `lib/conversations.test.ts` due `localStorage.clear is not a function` in this environment (unrelated to this diff)
