### PR TITLE
fix: multi-workspace agent discovery + CLI JSON parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ ELEVENLABS_API_KEY   # Optional -- voice indicators
 
 Run `npm run setup` to auto-detect all required values from your local OpenClaw installation.
 
-**Workspace detection order:** `~/.openclaw/agents/main/workspace` (current layout) → `~/.openclaw/workspace` (legacy). Falls back to manual prompt if neither exists.
+**Workspace detection order:** `~/.openclaw/openclaw.json` → `agents.defaults.workspace` (canonical) → legacy filesystem paths. Falls back to manual prompt if none found.
 
 **Global install:** When installed via `npm install -g clawport-ui`, `.env.local` may not be writable in the package directory. Setup falls back to `~/.config/clawport-ui/.env.local` (XDG-compliant). The CLI (`bin/clawport.mjs`) checks both locations when loading env vars.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All AI calls -- chat, vision, TTS, transcription -- route through the gateway. O
 
 | Variable | Description | How to find it |
 |----------|-------------|----------------|
-| `WORKSPACE_PATH` | Path to your OpenClaw workspace | Default: `~/.openclaw/agents/main/workspace` (or legacy `~/.openclaw/workspace`) |
+| `WORKSPACE_PATH` | Path to your OpenClaw workspace | Read from `~/.openclaw/openclaw.json` (agents.defaults.workspace) |
 | `OPENCLAW_BIN` | Path to the `openclaw` binary | Run `which openclaw` |
 | `OPENCLAW_GATEWAY_TOKEN` | Gateway auth token | Run `openclaw gateway status` |
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -105,7 +105,7 @@ clawport setup
 npm run setup
 ```
 
-This auto-detects your `WORKSPACE_PATH` (checks both current and legacy OpenClaw layouts), `OPENCLAW_BIN`, and gateway token from your local OpenClaw installation, shows you what it found, and writes `.env.local` after you confirm.
+This auto-detects your `WORKSPACE_PATH` (reads from `~/.openclaw/openclaw.json` agents.defaults.workspace), `OPENCLAW_BIN`, and gateway token from your local OpenClaw installation, shows you what it found, and writes `.env.local` after you confirm.
 
 When installed globally via `npm install -g clawport-ui`, the package directory may not be writable. In that case, setup automatically writes `.env.local` to `~/.config/clawport-ui/` instead. The CLI checks both locations when loading environment variables.
 
@@ -121,16 +121,14 @@ Open `.env.local` in your editor and set the three required variables.
 
 The path to your OpenClaw workspace directory. This is where OpenClaw stores agent SOUL files, memory, and other data.
 
-**Default locations (checked in order):**
-1. `~/.openclaw/agents/main/workspace` (current OpenClaw layout)
-2. `~/.openclaw/workspace` (legacy layout)
+**How it's detected:**
 
-To verify:
+Setup reads `agents.defaults.workspace` from `~/.openclaw/openclaw.json` (the canonical source). If not found there, it falls back to legacy filesystem paths.
+
+To verify your configured workspace:
 
 ```bash
-ls ~/.openclaw/agents/main/workspace
-# or for legacy installs:
-ls ~/.openclaw/workspace
+cat ~/.openclaw/openclaw.json | grep -A1 '"workspace"'
 ```
 
 You should see files like `SOUL.md`, an `agents/` directory, and a `memory/` directory. Use the full absolute path in your `.env.local`:

--- a/app/api/chat/[id]/route.ts
+++ b/app/api/chat/[id]/route.ts
@@ -3,21 +3,17 @@ export const runtime = 'nodejs'
 import { getAgent } from '@/lib/agents'
 import { validateChatMessages } from '@/lib/validation'
 import { hasImageContent, extractImageAttachments, buildTextPrompt, sendViaOpenClaw } from '@/lib/anthropic'
-import OpenAI from 'openai'
-import { gatewayBaseUrl } from '@/lib/env'
+import { getOpenAIClient } from '@/lib/openai'
+import { gatewayToken } from '@/lib/env'
+import type OpenAI from 'openai'
 
-// Route through the OpenClaw gateway — no separate API key needed
-const openai = new OpenAI({
-  baseURL: gatewayBaseUrl(),
-  apiKey: process.env.OPENCLAW_GATEWAY_TOKEN,
-})
-
-const GATEWAY_TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN || ''
+const GATEWAY_TOKEN = gatewayToken()
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const openai = getOpenAIClient()
   const { id } = await params
   const agent = await getAgent(id)
 

--- a/app/api/kanban/chat/[id]/route.ts
+++ b/app/api/kanban/chat/[id]/route.ts
@@ -1,13 +1,8 @@
 export const runtime = 'nodejs'
 
 import { getAgent } from '@/lib/agents'
-import OpenAI from 'openai'
-import { gatewayBaseUrl } from '@/lib/env'
-
-const openai = new OpenAI({
-  baseURL: gatewayBaseUrl(),
-  apiKey: process.env.OPENCLAW_GATEWAY_TOKEN,
-})
+import { getOpenAIClient } from '@/lib/openai'
+import type OpenAI from 'openai'
 
 const MAX_TITLE = 500
 const MAX_DESC = 5000
@@ -27,6 +22,7 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const openai = getOpenAIClient()
   const { id } = await params
   const agent = await getAgent(id)
 

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,14 +1,9 @@
 export const runtime = 'nodejs'
 
-import OpenAI from 'openai'
-import { gatewayBaseUrl } from '@/lib/env'
-
-const openai = new OpenAI({
-  baseURL: gatewayBaseUrl(),
-  apiKey: process.env.OPENCLAW_GATEWAY_TOKEN,
-})
+import { getOpenAIClient } from '@/lib/openai'
 
 export async function POST(request: Request) {
+  const openai = getOpenAIClient()
   let formData: FormData
   try {
     formData = await request.formData()

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,14 +1,9 @@
 export const runtime = 'nodejs'
 
-import OpenAI from 'openai'
-import { gatewayBaseUrl } from '@/lib/env'
-
-const openai = new OpenAI({
-  baseURL: gatewayBaseUrl(),
-  apiKey: process.env.OPENCLAW_GATEWAY_TOKEN,
-})
+import { getOpenAIClient } from '@/lib/openai'
 
 export async function POST(request: Request) {
+  const openai = getOpenAIClient()
   try {
     const { text, voice } = await request.json()
 

--- a/lib/agents-registry.ts
+++ b/lib/agents-registry.ts
@@ -474,31 +474,42 @@ function mergeExtraWorkspaces(
     // Skip agents whose workspace matches the primary (already discovered)
     if (!ws || ws === primaryWorkspace) continue
 
+    // Use CLI agent ID as the canonical ID for this workspace
+    const cliId = cli.id
+    if (existingIds.has(cliId)) continue
+
     // Try discovering agents from this workspace's filesystem
     const discovered = discoverAgents(ws)
-    if (discovered) {
-      // Enrich with model from this CLI agent
-      if (cli.model) {
-        for (const d of discovered) {
-          if (!d.model) d.model = cli.model
-        }
-      }
-      for (const agent of discovered) {
-        if (existingIds.has(agent.id)) continue
-        // Agents from other workspaces are top-level peers (no cross-workspace hierarchy)
-        if (agent.reportsTo && !existingIds.has(agent.reportsTo)) {
-          agent.reportsTo = null
-        }
-        added.push(agent)
-        existingIds.add(agent.id)
-      }
-    } else {
-      // Workspace has no agents/ dir — create a minimal entry from CLI identity
-      const id = cli.id
-      if (existingIds.has(id)) continue
-      const name = cli.identityName || slugToName(id)
+
+    if (discovered && discovered.length > 0) {
+      // Take the first (root) agent from discovered and merge with CLI data
+      const discoveredAgent = discovered[0]
+
+      // Use CLI ID as canonical, prefer CLI identity if available, otherwise slug from ID
+      const name = cli.identityName || slugToName(cliId)
+      const emoji = cli.identityEmoji || name.charAt(0).toUpperCase()
+
       added.push({
-        id,
+        id: cliId,
+        name,
+        title: discoveredAgent.title || 'Agent',
+        reportsTo: null,
+        directReports: [],
+        soulPath: discoveredAgent.soulPath,
+        voiceId: discoveredAgent.voiceId,
+        color: DISCOVER_COLORS[colorIndex++ % DISCOVER_COLORS.length],
+        emoji,
+        tools: discoveredAgent.tools,
+        model: cli.model || discoveredAgent.model,
+        memoryPath: discoveredAgent.memoryPath,
+        description: discoveredAgent.description || `${name} agent.`,
+      })
+      existingIds.add(cliId)
+    } else {
+      // Workspace has no discoverable agents — create a minimal entry from CLI identity
+      const name = cli.identityName || slugToName(cliId)
+      added.push({
+        id: cliId,
         name,
         title: 'Agent',
         reportsTo: null,
@@ -512,7 +523,7 @@ function mergeExtraWorkspaces(
         memoryPath: null,
         description: `${name} agent.`,
       })
-      existingIds.add(id)
+      existingIds.add(cliId)
     }
   }
 

--- a/lib/cli-utils.ts
+++ b/lib/cli-utils.ts
@@ -1,25 +1,66 @@
 /**
- * Extract a JSON value from CLI output that may contain non-JSON preamble.
+ * Extract a JSON value from CLI output that may contain non-JSON preamble or epilogue.
  *
  * Some OpenClaw versions print validation warnings (e.g. "Unrecognized key")
- * to stdout before the JSON payload. This function finds the first `[` or `{`
- * and parses from there, so ClawPort doesn't break on noisy CLI output.
+ * or plugin logs (e.g. "[plugins] ...") to stdout before/after the JSON payload.
+ * This function finds and extracts only the valid JSON structure.
  */
 export function extractJson(raw: string): unknown {
-  // Fast path: raw is already valid JSON
-  const trimmed = raw.trim()
-  if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
-    return JSON.parse(trimmed)
+  const lines = raw.split('\n')
+  let jsonStartLine = -1
+  let jsonType: '[' | '{' | null = null
+
+  for (let i = 0; i < lines.length; i++) {
+    // Strip ANSI escape codes
+    const cleanLine = lines[i].replace(/\x1b\[[0-9;]*m/g, '').trim()
+
+    if (cleanLine.startsWith('{')) {
+      jsonStartLine = i
+      jsonType = '{'
+      break
+    }
+    if (cleanLine.startsWith('[')) {
+      // Check if this is a JSON array start
+      // - Line is just "[" (empty array or array start on new line)
+      // - OR next char is whitespace, quote, bracket, or digit (JSON array content)
+      // NOT a log tag like [plugins] where next char is a letter
+      const nextChar = cleanLine[1]
+      if (!nextChar || /[\s"'\{\[\d]/.test(nextChar)) {
+        jsonStartLine = i
+        jsonType = '['
+        break
+      }
+    }
   }
 
-  // Find the first JSON structure in the output
-  const arrStart = raw.indexOf('[')
-  const objStart = raw.indexOf('{')
-  const starts = [arrStart, objStart].filter(i => i >= 0)
-  if (starts.length === 0) {
+  if (jsonStartLine < 0) {
     throw new SyntaxError('No JSON found in CLI output')
   }
 
-  const start = Math.min(...starts)
-  return JSON.parse(raw.slice(start))
+  // Find where the JSON ends by matching brackets
+  const jsonLines = lines.slice(jsonStartLine)
+  let depth = 0
+  let jsonEndLine = -1
+
+  for (let i = 0; i < jsonLines.length; i++) {
+    const line = jsonLines[i].replace(/\x1b\[[0-9;]*m/g, '')
+    for (const char of line) {
+      if (char === '[' || char === '{') depth++
+      else if (char === ']' || char === '}') {
+        depth--
+        if (depth === 0) {
+          jsonEndLine = i
+          break
+        }
+      }
+    }
+    if (jsonEndLine >= 0) break
+  }
+
+  if (jsonEndLine < 0) {
+    throw new SyntaxError('JSON structure not properly closed')
+  }
+
+  const jsonPart = jsonLines.slice(0, jsonEndLine + 1).join('\n')
+  return JSON.parse(jsonPart)
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -22,3 +22,8 @@ export function gatewayPort(): number {
 export function gatewayBaseUrl(): string {
   return `http://localhost:${gatewayPort()}/v1`
 }
+
+/** OpenClaw gateway auth token. */
+export function gatewayToken(): string {
+  return process.env.OPENCLAW_GATEWAY_TOKEN || ''
+}

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -1,0 +1,20 @@
+import OpenAI from 'openai'
+import { gatewayBaseUrl, gatewayToken } from './env'
+
+/**
+ * Lazy-initialized OpenAI client for the OpenClaw gateway.
+ *
+ * IMPORTANT: Call this inside route handlers, not at module top level.
+ * This prevents build errors when environment variables aren't set during build.
+ */
+let _openai: OpenAI | null = null
+
+export function getOpenAIClient(): OpenAI {
+  if (!_openai) {
+    _openai = new OpenAI({
+      baseURL: gatewayBaseUrl(),
+      apiKey: gatewayToken(),
+    })
+  }
+  return _openai
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -44,16 +44,30 @@ function exec(cmd) {
 
 function detectWorkspacePath() {
   const base = join(homedir(), '.openclaw')
+  const configPath = join(base, 'openclaw.json')
 
-  // 1. Current agent-scoped layout
+  // 1. Read from openclaw.json agents.defaults.workspace (canonical source)
+  if (existsSync(configPath)) {
+    try {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      const defaultWorkspace = config?.agents?.defaults?.workspace
+      if (typeof defaultWorkspace === 'string' && existsSync(defaultWorkspace)) {
+        return defaultWorkspace
+      }
+    } catch {
+      // Invalid JSON, fall through
+    }
+  }
+
+  // 2. Current agent-scoped layout (legacy fallback)
   const agentPath = join(base, 'agents', 'main', 'workspace')
   if (existsSync(agentPath)) return agentPath
 
-  // 2. Multi-agent layout: workspace-main
+  // 3. Multi-agent layout: workspace-main
   const multiMain = join(base, 'workspace-main')
   if (existsSync(multiMain)) return multiMain
 
-  // 3. Multi-agent layout: first workspace-<agentId> found
+  // 4. Multi-agent layout: first workspace-<agentId> found
   try {
     const entries = readdirSync(base)
     const workspaceDirs = entries
@@ -64,7 +78,7 @@ function detectWorkspacePath() {
     // ~/.openclaw doesn't exist
   }
 
-  // 4. Legacy single-workspace layout
+  // 5. Legacy single-workspace layout
   const legacyPath = join(base, 'workspace')
   if (existsSync(legacyPath)) return legacyPath
 


### PR DESCRIPTION
 ## Summary
  - Setup script now reads workspace path from `openclaw.json`
  (`agents.defaults.workspace`) instead of hardcoded paths
  - Agent discovery uses CLI agent ID as canonical identifier for multi-workspace
  setups
  - `extractJson()` properly handles plugin log output before/after JSON payload
  - OpenAI client lazy-initialized to prevent build errors when env vars not set

  ## Problem Solved
  This fixes agent discovery for users with `openclaw agent add --workspace`
  setups. Previously, only the main agent was discovered correctly because the
  setup script only looked at hardcoded workspace paths. Now it respects the
  workspace configuration in `openclaw.json`.

  Also fixes JSON parsing errors when CLI commands output plugin logs alongside
  the JSON payload.

  ## Test plan
  - [x] Run `npm run setup` with a multi-workspace OpenClaw setup
  - [ ] Verify all agents are discovered with correct IDs from CLI
  - [ ] Verify JSON parsing handles `[plugins]` log output correctly

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: GLM-5 <noreply@zhipuai.cn>
  Co-Authored-By: Claude <noreply@anthropic.com>
