### PR TITLE
Fix memory status always showing Not indexed

### DIFF
--- a/lib/memory.test.ts
+++ b/lib/memory.test.ts
@@ -283,17 +283,19 @@ describe('getMemoryStatus', () => {
   })
 
   it('parses valid JSON status', () => {
-    mockExecSync.mockReturnValue(JSON.stringify({
-      indexed: true,
-      lastIndexed: '2026-03-01T12:00:00Z',
-      totalEntries: 42,
-      vectorAvailable: true,
-      embeddingProvider: 'openai',
-    }))
+    mockExecSync.mockReturnValue(JSON.stringify([{
+      agentId: 'main',
+      status: {
+        files: 9,
+        chunks: 42,
+        dirty: false,
+        provider: 'openai',
+        vector: { available: true },
+      },
+    }]))
 
     const status = getMemoryStatus()
     expect(status.indexed).toBe(true)
-    expect(status.lastIndexed).toBe('2026-03-01T12:00:00Z')
     expect(status.totalEntries).toBe(42)
     expect(status.vectorAvailable).toBe(true)
     expect(status.embeddingProvider).toBe('openai')
@@ -324,12 +326,36 @@ describe('getMemoryStatus', () => {
   })
 
   it('handles missing fields in JSON response', () => {
-    mockExecSync.mockReturnValue(JSON.stringify({ indexed: true }))
+    mockExecSync.mockReturnValue(JSON.stringify([{
+      agentId: 'main',
+      status: { files: 1, chunks: 1, dirty: false },
+    }]))
 
     const status = getMemoryStatus()
     expect(status.indexed).toBe(true)
     expect(status.lastIndexed).toBeNull()
-    expect(status.totalEntries).toBeNull()
+    expect(status.totalEntries).toBe(1)
+  })
+
+  it('reports not indexed when agent has dirty files', () => {
+    mockExecSync.mockReturnValue(JSON.stringify([{
+      agentId: 'main',
+      status: { files: 9, chunks: 13, dirty: true, provider: 'gemini' },
+    }]))
+
+    const status = getMemoryStatus()
+    expect(status.indexed).toBe(false)
+  })
+
+  it('aggregates entries across multiple agents', () => {
+    mockExecSync.mockReturnValue(JSON.stringify([
+      { agentId: 'main', status: { files: 9, chunks: 13, dirty: false, provider: 'gemini', vector: { available: true } } },
+      { agentId: 'courier', status: { files: 2, chunks: 2, dirty: false } },
+    ]))
+
+    const status = getMemoryStatus()
+    expect(status.indexed).toBe(true)
+    expect(status.totalEntries).toBe(15)
   })
 })
 

--- a/lib/memory.ts
+++ b/lib/memory.ts
@@ -1,4 +1,4 @@
-import type { MemoryFileInfo, MemoryConfig, MemoryStatus, MemoryStats } from '@/lib/types'
+import type { AgentDeepStatus, MemoryFileInfo, MemoryConfig, MemoryStatus, MemoryStats } from '@/lib/types'
 import { readFileSync, existsSync, statSync, readdirSync } from 'fs'
 import { join, basename, dirname } from 'path'
 import { execSync } from 'child_process'
@@ -212,26 +212,38 @@ export function getMemoryStatus(): MemoryStatus {
     return defaults
   }
 
+  // Note: execSync with hardcoded args is safe here — no user input in command
   try {
-    const output = execSync(`${bin} memory status --deep`, {
+    const output = execSync(`${bin} memory status --deep --json`, {
       timeout: 15000,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim()
 
-    // Try JSON parse first
     try {
-      const data = JSON.parse(output)
+      const data: unknown = JSON.parse(output)
+      // openclaw returns an array of per-agent status objects
+      const agents: AgentDeepStatus[] = Array.isArray(data) ? data : [data]
+      const primary = agents[0]?.status
+      if (!primary) return { ...defaults, raw: output }
+
+      const totalEntries = agents.reduce(
+        (sum, a) => sum + (a.status?.chunks ?? 0),
+        0,
+      )
+      const allIndexed = agents.every(
+        a => (a.status?.files ?? 0) > 0 && !a.status?.dirty,
+      )
+
       return {
-        indexed: data.indexed ?? false,
-        lastIndexed: data.lastIndexed ?? null,
-        totalEntries: data.totalEntries ?? null,
-        vectorAvailable: data.vectorAvailable ?? null,
-        embeddingProvider: data.embeddingProvider ?? null,
+        indexed: allIndexed,
+        lastIndexed: null,
+        totalEntries,
+        vectorAvailable: primary.vector?.available ?? null,
+        embeddingProvider: primary.provider ?? null,
         raw: output,
       }
     } catch {
-      // Plain text fallback
       return { ...defaults, raw: output }
     }
   } catch {

--- a/lib/setup-scenarios.test.ts
+++ b/lib/setup-scenarios.test.ts
@@ -578,17 +578,19 @@ describe('Existing user (fully configured workspace)', () => {
   describe('memory status — CLI returns JSON', () => {
     it('parses full memory status from CLI', () => {
       vi.stubEnv('OPENCLAW_BIN', OPENCLAW_BIN)
-      mockExecSync.mockReturnValue(JSON.stringify({
-        indexed: true,
-        lastIndexed: '2026-03-04T08:00:00Z',
-        totalEntries: 128,
-        vectorAvailable: true,
-        embeddingProvider: 'openai',
-      }))
+      mockExecSync.mockReturnValue(JSON.stringify([{
+        agentId: 'main',
+        status: {
+          files: 9,
+          chunks: 128,
+          dirty: false,
+          provider: 'openai',
+          vector: { available: true },
+        },
+      }]))
 
       const status = getMemoryStatus()
       expect(status.indexed).toBe(true)
-      expect(status.lastIndexed).toBe('2026-03-04T08:00:00Z')
       expect(status.totalEntries).toBe(128)
       expect(status.vectorAvailable).toBe(true)
       expect(status.embeddingProvider).toBe('openai')

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -216,6 +216,17 @@ export interface MemoryStatus {
   raw: string
 }
 
+export interface AgentDeepStatus {
+  agentId?: string
+  status?: {
+    files?: number
+    chunks?: number
+    dirty?: boolean
+    provider?: string
+    vector?: { available?: boolean }
+  }
+}
+
 export interface MemoryStats {
   totalFiles: number
   totalSizeBytes: number


### PR DESCRIPTION
## Summary

- `getMemoryStatus()` now passes `--json` to `openclaw memory status --deep` so the response is machine-parseable
- Rewrites the parser to handle the actual array-of-agents response format instead of expecting a flat `{ indexed: true }` object
- Derives `indexed` from `files > 0 && dirty === false` across all agents; aggregates `totalEntries` from chunk counts
- Adds `AgentDeepStatus` type to `lib/types.ts`

Closes #24

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 804/804 passing (was 799/802 before fix)
- [x] Updated existing tests to use real openclaw response format
- [x] Added test for dirty-file detection (should report not indexed)
- [x] Added test for multi-agent entry aggregation
- [x] Verified locally: memory page now shows green "Indexed" dot